### PR TITLE
Added POM scanner file,example pom file and commands to run it from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ files on disk for intermediate processing which is suboptimal for most cases,
 although makes examination of incredibly large files possible. Some of the
 results are spurious so use it with a lower confidence interval.
 
+#### Pom
+
+Pom is a backend for parsing Project Object Model or POM files. It finds names
+of licenses in the licenses field of the `pom.xml` file which are commonly used
+by the Maven Project. This parser sometimes cannot identify licenses due to the
+name being written in its full form.
+
 #### Spdx
 
 This is a simple pure-golang, SPDX parser. It should find anything that is a

--- a/backend/pom.go
+++ b/backend/pom.go
@@ -1,0 +1,135 @@
+// Copyright Amazon.com Inc or its affiliates and the project contributors
+// Written by James Shubin <purple@amazon.com> and the project contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+// We will never require a CLA to submit a patch. All contributions follow the
+// `inbound == outbound` rule.
+//
+// This is not an official Amazon product. Amazon does not offer support for
+// this project.
+
+// TODO: should this be a subpackage?
+package backend
+
+import (
+	"context"
+	"encoding/xml"
+	"sort"
+
+	"github.com/awslabs/yesiscan/interfaces"
+	"github.com/awslabs/yesiscan/util/errwrap"
+	"github.com/awslabs/yesiscan/util/licenses"
+)
+
+const (
+	// PomFilename is the file name used by the pomfiles.
+	PomFilename = "pom.xml"
+)
+
+// Pom is a backend for Pom or Project Object Model files. It is an xml file
+// commonly used by the Maven Project under the name pom.xml. We are getting the
+// license names by parsing the pom.xml file.
+type Pom struct {
+	Debug bool
+	Logf  func(format string, v ...interface{})
+}
+
+// String method returns the name of the backend.
+func (obj *Pom) String() string {
+	return "pom"
+}
+
+// ScanData method is used to extract license ids from data and return licenses
+// based on the license ids.
+func (obj *Pom) ScanData(ctx context.Context, data []byte, info *interfaces.Info) (*interfaces.Result, error) {
+	// This check is taking place with the assumption that the file that will be
+	// scanned will have to be named "pom.xml".
+	if info.FileInfo.Name() != PomFilename {
+		return nil, nil // skip
+	}
+	if info.FileInfo.IsDir() {
+		return nil, nil // skip
+	}
+	if len(data) == 0 {
+		return nil, nil // skip
+	}
+
+	licenseMap := make(map[string]struct{})
+	var pomFileLicenses PomLicenses
+
+	// parsing pom.xml file to get license names in struct
+	if err := xml.Unmarshal(data, &pomFileLicenses); err != nil {
+		// NOTE: This is NOT the same as as interfaces.ErrUnknownLicense since here we
+		// are checking if any error takes place while parsing the xml file for
+		// license names.
+		return nil, errwrap.Wrapf(err, "parse error")
+	}
+
+	if len(pomFileLicenses.Names) == 0 {
+		// If we did not get any license names from the pom file we return nil, nil.
+		return nil, nil
+	}
+
+	// lid is license id
+	for _, lid := range pomFileLicenses.Names {
+		licenseMap[lid] = struct{}{}
+	}
+
+	ids := []string{}
+	for id := range licenseMap {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids) // deterministic order
+
+	licenseList := []*licenses.License{}
+
+	for _, id := range ids {
+		license := &licenses.License{
+			SPDX: id,
+			// TODO: populate other fields here?
+		}
+
+		// If we find an unknown SPDX ID, we don't want to error, because that would
+		// allow someone to put junk in their code to prevent us scanning it. Instead,
+		// create an invalid license but return it anyways. If we ever want to check
+		// validity, we know to expect failures.
+		// XXX: Many Pom licenses are not SPDX, therefore we might want to add an alias
+		// matcher in the future.
+		if err := license.Validate(); err != nil {
+			//return nil, err
+			license = &licenses.License{
+				//SPDX: "",
+				Origin: "", // unknown!
+				Custom: id,
+				// TODO: populate other fields here (eg: found license text)
+			}
+		}
+
+		licenseList = append(licenseList, license)
+	}
+
+	result := &interfaces.Result{
+		Licenses:   licenseList,
+		Confidence: 1.0, // TODO: what should we put here?
+	}
+
+	return result, nil
+}
+
+// PomLicenses is a struct that helps store license names from the licenses
+// field in a pom.xml file.
+type PomLicenses struct {
+	// Names is a variable that will store the license names from pom.xml.
+	Names []string `xml:"licenses>license>name"`
+}

--- a/cmd/yesiscan/main.go
+++ b/cmd/yesiscan/main.go
@@ -64,12 +64,14 @@ func CLI(program string, debug bool, logf func(format string, v ...interface{}))
 			flags := make(map[string]bool)
 			names := []string{
 				"no-backend-licenseclassifier",
+				"no-backend-pom",
 				"no-backend-spdx",
 				"no-backend-askalono",
 				"no-backend-scancode",
 				"no-backend-bitbake",
 				"no-backend-regexp",
 				"yes-backend-licenseclassifier",
+				"yes-backend-pom",
 				"yes-backend-spdx",
 				"yes-backend-askalono",
 				"yes-backend-scancode",
@@ -102,6 +104,7 @@ func CLI(program string, debug bool, logf func(format string, v ...interface{}))
 		},
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "no-backend-licenseclassifier"},
+			&cli.BoolFlag{Name: "no-backend-pom"},
 			&cli.BoolFlag{Name: "no-backend-spdx"},
 			&cli.BoolFlag{Name: "no-backend-askalono"},
 			&cli.BoolFlag{Name: "no-backend-scancode"},
@@ -110,6 +113,7 @@ func CLI(program string, debug bool, logf func(format string, v ...interface{}))
 			&cli.StringFlag{Name: "regexp-path"},
 			//&cli.BoolFlag{Name: "no-backend-example"},
 			&cli.BoolFlag{Name: "yes-backend-licenseclassifier"},
+			&cli.BoolFlag{Name: "yes-backend-pom"},
 			&cli.BoolFlag{Name: "yes-backend-spdx"},
 			&cli.BoolFlag{Name: "yes-backend-askalono"},
 			&cli.BoolFlag{Name: "yes-backend-scancode"},

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.neo4j.build.plugins</groupId>
+    <artifactId>license-maven-plugin</artifactId>
+    <version>4-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <properties>
+      <jdk>1.6</jdk>
+      <jdk.version>1.6</jdk.version>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+</project>

--- a/lib/main.go
+++ b/lib/main.go
@@ -138,6 +138,7 @@ func (obj *Main) Run(ctx context.Context) error {
 	// is there at least one yes-?
 	isAdditive := false ||
 		Bool("yes-backend-licenseclassifier") ||
+		Bool("yes-backend-pom") ||
 		Bool("yes-backend-spdx") ||
 		Bool("yes-backend-askalono") ||
 		Bool("yes-backend-scancode") ||
@@ -171,6 +172,17 @@ func (obj *Main) Run(ctx context.Context) error {
 		}
 		backends = append(backends, licenseClassifierBackend)
 		backendWeights[licenseClassifierBackend] = 1.0 // TODO: adjust as needed
+	}
+
+	if cliFlag("pom") {
+		pomBackend := &backend.Pom{
+			Debug: obj.Debug,
+			Logf: func(format string, v ...interface{}) {
+				obj.Logf("backend: "+format, v...)
+			},
+		}
+		backends = append(backends, pomBackend)
+		backendWeights[pomBackend] = 2.0 // TODO: adjust as needed
 	}
 
 	if cliFlag("spdx") {


### PR DESCRIPTION
I have added a `pom.go` file which scans only "pom.xml" files and won't scan any other file. It will fetch the license name or names from that specific xml file. If you try it with the example file given in `examples/.pom` you should receive "The Apache Software License, Version 2.0". I also added the pom struct in lib/main.go and I have added the commands to test it through the command line by adding the commands in `cmd/yesiscan/main.go`. So far I have tested with these two repositories with just the `yesiscan --yes-backend-pom` command and it gets the license name as stated above:

- https://github.com/neo4j/license-maven-plugin
- https://github.com/quarkusio/quarkus

So this works minimally so far. I think it can be improved in the case that it does not recognize "The Apache Software License, Version 2.0" since it would be recognizable if it was named to be "Apache-2.0".

This is regarding issue 10