### PR TITLE
zip: Added whl extension to be unwrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ eventually end up with an fs iterator to do the actual work.
 The zip iterator can decompress and extract zip files. It uses a heuristic to
 decide whether a file should be extracted or not. It usually does the right
 thing, but if you can find a corner case where it does not, please let us know.
-It also handles java `.jar` files since those are basically zip files in
-disguise.
+It also handles java `.jar` and python `.whl` files since those are basically
+zip files in disguise.
 
 #### tar
 

--- a/iterator/fs.go
+++ b/iterator/fs.go
@@ -164,7 +164,7 @@ func (obj *Fs) Recurse(ctx context.Context, scan interfaces.ScanFunc) ([]interfa
 			UID:      uid,
 		}
 
-		if absFile.HasExtInsensitive(ZipExtension) || absFile.HasExtInsensitive(JarExtension) {
+		if absFile.HasExtInsensitive(ZipExtension) || absFile.HasExtInsensitive(JarExtension) || absFile.HasExtInsensitive(WhlExtension) {
 			iterator := &Zip{
 				Debug: obj.Debug,
 				Logf: func(format string, v ...interface{}) {
@@ -180,6 +180,7 @@ func (obj *Fs) Recurse(ctx context.Context, scan interfaces.ScanFunc) ([]interfa
 				AllowedExtensions: []string{
 					ZipExtension,
 					JarExtension,
+					WhlExtension,
 				},
 			}
 
@@ -336,7 +337,7 @@ func (obj *Fs) Recurse(ctx context.Context, scan interfaces.ScanFunc) ([]interfa
 			// connect into this fs iterator... This will avoid a
 			// lot of code duplication and also prevent us from
 			// forgetting to add these everywhere...
-			if absFile.HasExtInsensitive(ZipExtension) || absFile.HasExtInsensitive(JarExtension) {
+			if absFile.HasExtInsensitive(ZipExtension) || absFile.HasExtInsensitive(JarExtension) || absFile.HasExtInsensitive(WhlExtension) {
 				iterator := &Zip{
 					Debug: obj.Debug,
 					Logf: func(format string, v ...interface{}) {
@@ -352,6 +353,7 @@ func (obj *Fs) Recurse(ctx context.Context, scan interfaces.ScanFunc) ([]interfa
 					AllowedExtensions: []string{
 						ZipExtension,
 						JarExtension,
+						WhlExtension,
 					},
 				}
 

--- a/iterator/zip.go
+++ b/iterator/zip.go
@@ -44,6 +44,10 @@ const (
 	// JarExtension is used for java .jar files. This is included here since
 	// they are just zip files that are named differently.
 	JarExtension = ".jar"
+
+	// WhlExtension is used for python .whl files. This is included here since
+	// they are just zip files that are named differently.
+	WhlExtension = ".whl"
 )
 
 var (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -77,7 +77,8 @@ func (obj *TrivialURIParser) Parse() ([]interfaces.Iterator, error) {
 	// this is because we get https:// urls that are really github git URI's
 	isZip := strings.HasSuffix(strings.ToLower(s), iterator.ZipExtension)
 	isJar := strings.HasSuffix(strings.ToLower(s), iterator.JarExtension)
-	if strings.ToLower(u.Scheme) == iterator.HttpsSchemeRaw && (isZip || isJar) {
+	isWhl := strings.HasSuffix(strings.ToLower(s), iterator.WhlExtension)
+	if strings.ToLower(u.Scheme) == iterator.HttpsSchemeRaw && (isZip || isJar || isWhl) {
 		iterator := &iterator.Http{
 			Debug: obj.Debug,
 			Logf: func(format string, v ...interface{}) {


### PR DESCRIPTION
WhlExtension added in `zip.go` and added similar lines to how jar file extensions are handled in `fs.go` and `parser.go`
This is about issue #9 