### PR TITLE
Added regexp-file-pattern flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ Regexp is a backend that lets you match based on regular expressions. Nobody
 likes to do this, but it's very common. Put a config file at
 `~/.config/yesiscan/regexp.json` and then run the tool. An example file can be
 found in `[examples/regexp.json](examples/regexp.json)`. You can override the
-default path with the `--regexp-path` command line flag.
+default path with the `--regexp-path` command line flag. You can also add
+specific files that you want to be scanned by using `--regexp-file-pattern`.
 
 ### Caching
 

--- a/backend/regexp.go
+++ b/backend/regexp.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/awslabs/yesiscan/interfaces"
 	"github.com/awslabs/yesiscan/util/errwrap"
@@ -43,6 +44,10 @@ type Regexp struct {
 	// from. The struct is described below and an example is available in
 	// the examples folder.
 	Filename string
+
+	// FileNamePattern is a string which will contain a specific file 
+	// pattern and only scan files matching this specific pattern.
+	FileNamePattern string
 }
 
 func (obj *Regexp) String() string {
@@ -76,6 +81,14 @@ func (obj *Regexp) Setup(ctx context.Context) error {
 }
 
 func (obj *Regexp) ScanData(ctx context.Context, data []byte, info *interfaces.Info) (*interfaces.Result, error) {
+	match, err := regexp.MatchString(obj.FileNamePattern, info.FileInfo.Name())
+	if err != nil {
+		return nil, errwrap.Wrapf(err, "Incorrect file pattern")
+	}
+
+	if match == false {
+		return nil, nil // skip
+	}
 	return obj.RegexpCore.ScanData(ctx, data, info)
 }
 

--- a/cmd/yesiscan/main.go
+++ b/cmd/yesiscan/main.go
@@ -105,6 +105,8 @@ func CLI(program string, debug bool, logf func(format string, v ...interface{}))
 				Profiles: c.StringSlice("profile"),
 
 				RegexpPath: c.String("regexp-path"),
+
+				RegexpFilePattern: c.String("regexp-file-pattern"),
 			}
 
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -160,6 +162,7 @@ func CLI(program string, debug bool, logf func(format string, v ...interface{}))
 			&cli.BoolFlag{Name: "no-backend-bitbake"},
 			&cli.BoolFlag{Name: "no-backend-regexp"},
 			&cli.StringFlag{Name: "regexp-path"},
+			&cli.StringFlag{Name: "regexp-file-pattern"},
 			//&cli.BoolFlag{Name: "no-backend-example"},
 			&cli.BoolFlag{Name: "yes-backend-licenseclassifier"},
 			&cli.BoolFlag{Name: "yes-backend-cran"},

--- a/lib/main.go
+++ b/lib/main.go
@@ -58,6 +58,10 @@ type Main struct {
 
 	// RegexpPath specifies a path the regular expressions to use.
 	RegexpPath string
+
+	// RegexpFilePattern specifies files with specific file patterns
+	// to scan.
+	RegexpFilePattern string
 }
 
 // Run is the main method for the Main struct. We use a struct as a way to pass
@@ -248,7 +252,11 @@ func (obj *Main) Run(ctx context.Context) (*Output, error) {
 	}
 
 	regexpPath := ""
+	regexpFilePattern := ""
 	if cliFlag("regexp") {
+		if obj.RegexpFilePattern != "" {
+			regexpFilePattern = obj.RegexpFilePattern
+		}
 		if obj.RegexpPath != "" {
 			regexpPath = obj.RegexpPath
 		} else {
@@ -269,6 +277,7 @@ func (obj *Main) Run(ctx context.Context) (*Output, error) {
 			},
 
 			Filename: regexpPath,
+			FileNamePattern: regexpFilePattern,
 		}
 		backends = append(backends, regexpBackend)
 		backendWeights[regexpBackend] = 8.0 // TODO: adjust as needed


### PR DESCRIPTION
The regexp-file-pattern flag helps the regexp backend skip some files based on user input. For example we are running the following command:
`yesiscan --yes-backend-regexp --regexp-file-pattern .xml https://github.com/neo4j/license-maven-plugin.git`

The flag `--regexp-file-pattern` has an input of `.xml` which means it will only scan filenames with `.xml` in it. It can also be more specific such as `pom.xml` which would result in the regexp backend only scanning `pom.xml` files.
