### PR TITLE
Webrtc git repositories can be scanned

### DIFF
--- a/iterator/git.go
+++ b/iterator/git.go
@@ -188,9 +188,9 @@ func (obj *Git) Validate() error {
 			return err
 		}
 	}
-	// TODO: can we validate ref somehow?
+	// TODO: can we validate rev somehow?
 
-	if obj.Rev != "" {
+	if obj.Ref != "" {
 		if err := obj.validateRef(); err != nil {
 			return err
 		}

--- a/iterator/git.go
+++ b/iterator/git.go
@@ -223,8 +223,8 @@ func (obj *Git) validateRef() error {
 	if obj.Ref == plumbing.HEAD.String() {
 		return nil
 	}
-	Main := plumbing.NewBranchReferenceName("main") // not upstream
-	if obj.Ref == plumbing.Master.String() || obj.Ref == Main.String() {
+	main := plumbing.NewBranchReferenceName("main") // not upstream
+	if obj.Ref == plumbing.Master.String() || obj.Ref == main.String() {
 		return nil
 	}
 


### PR DESCRIPTION
This is regarding issue #28 

Webrtc git repositories can be scanned and can also scan `.tgz` or `.tar.gz` extensions can be scanned. I have also added the other extensions in `bzip2.go`, `tar.go` and `gzip.go` can be scanned as well when they come in an url. Github or webrtc urls with commit hashes can also be scanned.
