### PR TITLE
cmd: Add auto-config URI's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 old/
 tmp/
+.autoConfigURI
+.autoConfigCookiePath

--- a/README.md
+++ b/README.md
@@ -319,10 +319,10 @@ You can store your default configuration options in a
 `~/.config/yesiscan/config.json` file. This location can be overridden by the
 `--config-path` argument. If this file exists, then these values will be used as
 defaults. The below flags can override any of these. The following keys are
-supported: `quiet`, `regexp-path`, `output-type`, `output-path`,
-`output-s3bucket`, `region`, `profiles`, and `backends`. These keys should all
-be the top-level keys in a single json dictionary. More information on some of
-these keys are described below.
+supported: `auto-config-uri`, `auto-config-cookie-path`, `quiet`, `regexp-path`,
+`output-type`, `output-path`, `output-s3bucket`, `region`, `profiles`, and
+`backends`. These keys should all be the top-level keys in a single json
+dictionary. More information on some of these keys are described below.
 
 #### "profiles"
 
@@ -344,6 +344,24 @@ included by default unless you choose which one to exclude with the
 `--no-backend` variants. However if you use any of the `--yes-backend` variants,
 then you have to specify each backend that you want individually. You can get
 the full list of these flags with the `--help` flag.
+
+#### --auto-config-uri
+This is a special URI which if set, will try and pull a config from that
+location on startup. It will use the cookie file stored at
+`--auto-config-cookie-path` if specified. If successful, it will check if the
+config is different from what is currently stored. If so then it will validate
+if it is a valid json config. If so it will replace (overwrite!) the current
+config and then run with that!
+
+For example: `--auto-config-uri 'https://example.com/config.json'`.
+
+#### --auto-config-cookie-path
+This is a special URI which if set will point to a netscape/libcurl style cookie
+file to use when making the get download requests. This is useful if you store
+your config behind some gateway that needs a magic cookie for auth. It accepts
+the tilde (`~`) character to use for `$HOME` directory path expansion.
+
+For example:  `--auto-config-cookie-path '~/.secret/cookie'`.
 
 #### --quiet
 

--- a/cmd/yesiscan/Makefile
+++ b/cmd/yesiscan/Makefile
@@ -1,9 +1,13 @@
 .PHONY: all build release
 
+AUTO := $(shell cat ../../.autoConfigURI 2>/dev/null || echo '')
+COOKIE := $(shell cat ../../.autoConfigCookiePath 2>/dev/null || echo '')
+
 all: build
 
 build:
-	@go build && echo "built binary to: $(PWD)/yesiscan"
+	#@go build && echo "built binary to: $(PWD)/yesiscan"
+	@go build -ldflags="-X main.autoConfigURI=$(AUTO) -X main.autoConfigCookiePath=$(COOKIE)" && echo "built binary to: $(PWD)/yesiscan"
 
 release:
 	goreleaser release --skip-validate --rm-dist

--- a/cmd/yesiscan/main.go
+++ b/cmd/yesiscan/main.go
@@ -33,6 +33,8 @@ import (
 	"log"
 	"math"
 	"math/big"
+	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -46,6 +48,8 @@ import (
 	"github.com/awslabs/yesiscan/util/errwrap"
 	"github.com/awslabs/yesiscan/web"
 
+	"github.com/mitchellh/go-homedir"
+	"github.com/ssgelm/cookiejarparser"
 	cli "github.com/urfave/cli/v2" // imports as package "cli"
 )
 
@@ -59,16 +63,30 @@ var program string
 //go:embed .version
 var version string
 
+// autoConfigURI is set via -ldflags build time flags.
+var autoConfigURI string
+
+// autoConfigCookiePath is set via -ldflags build time flags.
+var autoConfigCookiePath string
+
 const (
 	// ConfigFileName is the name of the config file used to pull in all the
 	// various main settings that we want.
 	ConfigFileName = "config.json"
+
+	// MaxRedirects is the maximum number of redirects to allow for http
+	// download operations. The internal golang maximum of ten is too low
+	// for many situations. Firefox sets network.http.redirection-limit as
+	// 20.
+	MaxRedirects = 20 // do what firefox does
 )
 
 // CLI is the entry point for the CLI frontend.
 func CLI(program, version string, debug bool, logf func(format string, v ...interface{})) error {
 
 	flags := []cli.Flag{
+		&cli.StringFlag{Name: "auto-config-uri"},
+		&cli.StringFlag{Name: "auto-config-cookie-path"},
 		&cli.BoolFlag{Name: "quiet"},
 		&cli.StringFlag{Name: "regexp-path"},
 		&cli.StringFlag{Name: "config-path"},
@@ -95,273 +113,7 @@ func CLI(program, version string, debug bool, logf func(format string, v ...inte
 			logf("Hello from purpleidea! This is %s, version: %s", program, version)
 			defer logf("Done!")
 
-			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-			defer stop()
-
-			bigIntStr := "" // for our int
-			var quiet bool
-			var regexpPath string
-			// config-path makes no sense here
-			var outputType string
-			var outputPath string
-			var outputS3Bucket string
-			region := s3.DefaultRegion
-			profiles := []string{}
-			backends := make(map[string]bool)
-
-			// load from main config file or xdg if config is empty
-			config, err := GetConfig(c.String("config-path"))
-			if err != nil {
-				return err
-			}
-			if config != nil {
-				if config.Quiet != nil {
-					quiet = *config.Quiet
-				}
-				if config.RegexpPath != nil {
-					regexpPath = *config.RegexpPath
-				}
-				// config-path makes no sense here
-				if config.OutputType != nil {
-					outputType = *config.OutputType
-				}
-				if config.OutputPath != nil {
-					outputPath = *config.OutputPath
-				}
-				if config.OutputS3Bucket != nil {
-					outputS3Bucket = *config.OutputS3Bucket
-				}
-				if config.Region != nil {
-					region = *config.Region
-				}
-				if config.Profiles != nil {
-					profiles = []string{} // erase any previous
-					for _, x := range *config.Profiles {
-						profiles = append(profiles, x)
-					}
-				}
-				if config.Backends != nil {
-					for k, v := range config.Backends {
-						backends[k] = v // copy
-					}
-				}
-			}
-
-			// Command line options override anything in the config.
-			if c.IsSet("quiet") {
-				quiet = c.Bool("quiet")
-			}
-			if c.IsSet("regexp-path") {
-				regexpPath = c.String("regexp-path")
-			}
-			// config-path makes no sense here
-			if c.IsSet("output-type") {
-				outputType = c.String("output-type")
-			}
-			if c.IsSet("output-path") {
-				outputPath = c.String("output-path")
-			}
-			if c.IsSet("output-s3bucket") {
-				outputS3Bucket = c.String("output-s3bucket")
-			}
-			if c.IsSet("region") {
-				region = c.String("region")
-			}
-			if c.IsSet("profile") {
-				profiles = []string{} // erase any previous
-				for _, x := range c.StringSlice("profile") {
-					profiles = append(profiles, x)
-				}
-			}
-
-			if outputPath == "-" || quiet { // if output is stdout, noop logs
-				logf = func(format string, v ...interface{}) {
-					// noop
-				}
-			}
-			args := []string{}
-			for i := 0; i < c.NArg(); i++ {
-				s := c.Args().Get(i)
-				args = append(args, s)
-			}
-
-			// is there at least one yes-?
-			isAdditive := false
-			for _, f := range lib.Backends {
-				if c.Bool(fmt.Sprintf("yes-backend-%s", f)) {
-					isAdditive = true
-				}
-			}
-
-			// isBackendEnabled specifies if a particular backend
-			// should be enabled based on the lookup of the flags.
-			isBackendEnabled := func(f string) bool {
-				if isAdditive && c.Bool(fmt.Sprintf("yes-backend-%s", f)) {
-					return true
-				}
-
-				if !isAdditive && !c.Bool(fmt.Sprintf("no-backend-%s", f)) {
-					return true
-				}
-
-				return false
-			}
-
-			for _, b := range lib.Backends {
-				// if undefined, then look at the flags...
-				if _, exists := backends[b]; !exists {
-					backends[b] = isBackendEnabled(b)
-					continue
-				}
-				// if the yes or no flag was set, then use that
-				if c.Bool(fmt.Sprintf("no-backend-%s", b)) {
-					backends[b] = false
-				}
-				if c.Bool(fmt.Sprintf("yes-backend-%s", b)) {
-					backends[b] = true
-				}
-			}
-
-			if outputS3Bucket != "" { // do a test-for-auth run
-
-				bigInt, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
-				if err != nil {
-					return errwrap.Wrapf(err, "random number generation error")
-				}
-				bigIntStr = bigInt.String()
-
-				objectName := program // arbitrary, but unique
-				contentType := "text/plain"
-				inputs := &s3.Inputs{
-					Region:            region,
-					BucketName:        outputS3Bucket,
-					CreateBucket:      true,
-					ObjectName:        objectName,
-					GrantReadAllUsers: true,
-					ContentType:       &contentType,
-					Data:              []byte(program), // arbitrary
-					Debug:             debug,
-					Logf: func(format string, v ...interface{}) {
-						logf("s3: "+format, v...)
-					},
-				}
-				// XXX: find a way to check if credentials are
-				// good, early in the operation before the scan,
-				// otherwise we will end up running a whole scan
-				// and then throwing away the results...
-				if _, err := s3.Store(ctx, inputs); err != nil {
-					return errwrap.Wrapf(err, "s3 setup error")
-				}
-			}
-
-			m := &lib.Main{
-				Program: program,
-				Version: version,
-				Debug:   debug,
-				Logf:    logf,
-
-				Args:     args,
-				Backends: backends,
-
-				Profiles: profiles,
-
-				RegexpPath: regexpPath,
-			}
-
-			output, err := m.Run(ctx)
-			if err != nil {
-				return err
-			}
-
-			s := ""
-			if outputPath != "" || outputS3Bucket != "" {
-				var err error
-				// TODO: when we render an html version, should
-				// it look the same as the web `save` output?
-				if outputType == "text" {
-					if s, err = lib.ReturnOutputFile(output); err != nil {
-						return err
-					}
-				} else {
-					if s, err = web.ReturnOutputHtml(output); err != nil {
-						return err
-					}
-				}
-			}
-
-			if outputS3Bucket != "" {
-				ext := "html"
-				contentType := "text/html"
-				if outputType == "text" {
-					ext = "txt"
-					contentType = "text/plain"
-				}
-
-				// make a unique ID for the file
-				// XXX: we can consider different algorithms or methods here later...
-				// We want this hash to be basically impossible
-				// to guess, so that you can only get it if you
-				// have the secret link.
-				if bigIntStr == "" { // make sure we really have one
-					// programming error
-					return fmt.Errorf("random number generation logic error")
-				}
-				now := strconv.FormatInt(time.Now().UnixMilli(), 10) // itoa but int64
-				sum := sha512.Sum512([]byte(s + now + bigIntStr))    // XXX: for now
-				uid := fmt.Sprintf("%x", sum)
-				objectName := fmt.Sprintf("%s-%s.%s", program, uid, ext) // TODO: arbitrary
-
-				inputs := &s3.Inputs{
-					Region:            region,
-					BucketName:        outputS3Bucket,
-					CreateBucket:      true,
-					ObjectName:        objectName,
-					GrantReadAllUsers: true,
-					ContentType:       &contentType,
-					Data:              []byte(s),
-					Debug:             debug,
-					Logf: func(format string, v ...interface{}) {
-						logf("s3: "+format, v...)
-					},
-				}
-				// XXX: find a way to check if credentials are
-				// good, early in the operation before the scan,
-				// otherwise we will end up running a whole scan
-				// and then throwing away the results...
-				u, err := s3.Store(ctx, inputs)
-				if err != nil {
-					logf("could not write s3 file: %+v", err)
-				} else {
-					fmt.Printf("S3 Sig URL: %s\n", u)
-					fmt.Printf("S3 Pub URL: %s\n", s3.PubURL(region, outputS3Bucket, objectName))
-				}
-			}
-
-			if outputPath == "-" {
-				// NOTE: if we get asked for stdout, we
-				// turn off other output to make it sane
-				// TODO: should logs go to stderr instead?
-				quiet = true           // redundant for now
-				_, err := fmt.Print(s) // to stdout
-				return err
-
-			} else if outputPath != "" {
-				// TODO: is this the umask we should use?
-				if err := os.WriteFile(outputPath, []byte(s), interfaces.Umask); err != nil {
-					logf("could not write output file: %+v", err)
-				}
-			}
-
-			if !quiet {
-				s, err := lib.ReturnOutputConsole(output)
-				if err != nil {
-					return err
-				}
-
-				fmt.Print(s) // display it
-			}
-
-			return nil
+			return App(c, program, version, debug, logf)
 		},
 		Flags:                flags,
 		EnableBashCompletion: true,
@@ -387,9 +139,372 @@ func CLI(program, version string, debug bool, logf func(format string, v ...inte
 	return app.Run(os.Args)
 }
 
+// App is the main entry point action for the regular yesiscan cli application.
+func App(c *cli.Context, program, version string, debug bool, logf func(format string, v ...interface{})) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	bigIntStr := "" // for our int
+	var quiet bool
+	var regexpPath string
+	// config-path makes no sense here
+	var outputType string
+	var outputPath string
+	var outputS3Bucket string
+	region := s3.DefaultRegion
+	profiles := []string{}
+	backends := make(map[string]bool)
+
+	// load from main config file or xdg if config is empty
+	config, err := GetConfig(c.String("config-path"))
+	if err != nil {
+		return err
+	}
+	if config != nil {
+		if config.AutoConfigURI != nil {
+			// set this global var
+			autoConfigURI = *config.AutoConfigURI
+		}
+		if config.AutoConfigCookiePath != nil {
+			// set this global var
+			autoConfigCookiePath = *config.AutoConfigCookiePath
+		}
+		if config.Quiet != nil {
+			quiet = *config.Quiet
+		}
+		if config.RegexpPath != nil {
+			regexpPath = *config.RegexpPath
+		}
+		// config-path makes no sense here
+		if config.OutputType != nil {
+			outputType = *config.OutputType
+		}
+		if config.OutputPath != nil {
+			outputPath = *config.OutputPath
+		}
+		if config.OutputS3Bucket != nil {
+			outputS3Bucket = *config.OutputS3Bucket
+		}
+		if config.Region != nil {
+			region = *config.Region
+		}
+		if config.Profiles != nil {
+			profiles = []string{} // erase any previous
+			for _, x := range *config.Profiles {
+				profiles = append(profiles, x)
+			}
+		}
+		if config.Backends != nil {
+			for k, v := range config.Backends {
+				backends[k] = v // copy
+			}
+		}
+	}
+
+	// Command line options override anything in the config.
+	if c.IsSet("auto-config-uri") {
+		autoConfigURI = c.String("auto-config-uri")
+	}
+	if c.IsSet("auto-config-cookie-path") {
+		autoConfigCookiePath = c.String("auto-config-cookie-path")
+	}
+	if c.IsSet("quiet") {
+		quiet = c.Bool("quiet")
+	}
+	if c.IsSet("regexp-path") {
+		regexpPath = c.String("regexp-path")
+	}
+	// config-path makes no sense here
+	if c.IsSet("output-type") {
+		outputType = c.String("output-type")
+	}
+	if c.IsSet("output-path") {
+		outputPath = c.String("output-path")
+	}
+	if c.IsSet("output-s3bucket") {
+		outputS3Bucket = c.String("output-s3bucket")
+	}
+	if c.IsSet("region") {
+		region = c.String("region")
+	}
+	if c.IsSet("profile") {
+		profiles = []string{} // erase any previous
+		for _, x := range c.StringSlice("profile") {
+			profiles = append(profiles, x)
+		}
+	}
+
+	// auto config URI magic...
+	if autoConfigURI != "" { // we must try to auto config
+		logf("getting config from: %s", autoConfigURI)
+		data, err := DownloadConfig(autoConfigURI)
+		if err != nil {
+			return errwrap.Wrapf(err, "autoConfigURI download failed on: %s", autoConfigURI)
+		}
+		p, err := GetConfigPath(c.String("config-path"))
+		if err != nil {
+			return err
+		}
+		b, err := os.ReadFile(p)
+		if os.IsNotExist(err) { // no config exists here...
+			b = []byte{} // (implied, but now cleanly initialized)
+			err = nil    // clear this
+		} else if err != nil {
+			return err
+		}
+
+		isJson := func(d []byte) error {
+			buffer := bytes.NewBuffer(d)
+			if buffer.Len() == 0 {
+				return fmt.Errorf("empty config file")
+			}
+			decoder := json.NewDecoder(buffer)
+
+			var configData Config // this gets populated during decode
+			err := decoder.Decode(&configData)
+			return errwrap.Wrapf(err, "invalid json")
+		}
+
+		// if equal, we don't need to change the config...
+		// check it's valid json before writing it? (for portal errors)
+		if err := isJson(data); !bytes.Equal(data, b) && err == nil {
+
+			// store new config file
+			logf("writing new config...")
+			// XXX: set umask for u=rw,go=
+			if err := os.WriteFile(p, data, interfaces.Umask); err != nil {
+				return errwrap.Wrapf(err, "autoConfigURI store failed on: %s", p)
+			}
+
+			// recurse!
+			logf("recursing on new config...")
+			return App(c, program, version, debug, logf)
+
+		} else if err != nil {
+			// provide logs so users know something is wrong...
+			logf("invalid config file at URI: %s", autoConfigURI)
+			logf("error with config file: %+v", err)
+			if autoConfigCookiePath == "" {
+				logf("do you need an auth cookie?")
+			} else {
+				logf("is your auth cookie (%s) valid?", autoConfigCookiePath)
+			}
+		}
+	}
+
+	// XXX: pull from additional config file download paths and destinations
+
+	if outputPath == "-" || quiet { // if output is stdout, noop logs
+		logf = func(format string, v ...interface{}) {
+			// noop
+		}
+	}
+	args := []string{}
+	for i := 0; i < c.NArg(); i++ {
+		s := c.Args().Get(i)
+		args = append(args, s)
+	}
+
+	// is there at least one yes-?
+	isAdditive := false
+	for _, f := range lib.Backends {
+		if c.Bool(fmt.Sprintf("yes-backend-%s", f)) {
+			isAdditive = true
+		}
+	}
+
+	// isBackendEnabled specifies if a particular backend
+	// should be enabled based on the lookup of the flags.
+	isBackendEnabled := func(f string) bool {
+		if isAdditive && c.Bool(fmt.Sprintf("yes-backend-%s", f)) {
+			return true
+		}
+
+		if !isAdditive && !c.Bool(fmt.Sprintf("no-backend-%s", f)) {
+			return true
+		}
+
+		return false
+	}
+
+	for _, b := range lib.Backends {
+		// if undefined, then look at the flags...
+		if _, exists := backends[b]; !exists {
+			backends[b] = isBackendEnabled(b)
+			continue
+		}
+		// if the yes or no flag was set, then use that
+		if c.Bool(fmt.Sprintf("no-backend-%s", b)) {
+			backends[b] = false
+		}
+		if c.Bool(fmt.Sprintf("yes-backend-%s", b)) {
+			backends[b] = true
+		}
+	}
+
+	if outputS3Bucket != "" { // do a test-for-auth run
+
+		bigInt, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+		if err != nil {
+			return errwrap.Wrapf(err, "random number generation error")
+		}
+		bigIntStr = bigInt.String()
+
+		objectName := program // arbitrary, but unique
+		contentType := "text/plain"
+		inputs := &s3.Inputs{
+			Region:            region,
+			BucketName:        outputS3Bucket,
+			CreateBucket:      true,
+			ObjectName:        objectName,
+			GrantReadAllUsers: true,
+			ContentType:       &contentType,
+			Data:              []byte(program), // arbitrary
+			Debug:             debug,
+			Logf: func(format string, v ...interface{}) {
+				logf("s3: "+format, v...)
+			},
+		}
+		// XXX: find a way to check if credentials are
+		// good, early in the operation before the scan,
+		// otherwise we will end up running a whole scan
+		// and then throwing away the results...
+		logf("s3: setup verification...")
+		if _, err := s3.Store(ctx, inputs); err != nil {
+			return errwrap.Wrapf(err, "s3 setup error")
+		}
+	}
+
+	m := &lib.Main{
+		Program: program,
+		Version: version,
+		Debug:   debug,
+		Logf:    logf,
+
+		Args:     args,
+		Backends: backends,
+
+		Profiles: profiles,
+
+		RegexpPath: regexpPath,
+	}
+
+	output, err := m.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	s := ""
+	if outputPath != "" || outputS3Bucket != "" {
+		var err error
+		// TODO: when we render an html version, should
+		// it look the same as the web `save` output?
+		if outputType == "text" {
+			if s, err = lib.ReturnOutputFile(output); err != nil {
+				return err
+			}
+		} else {
+			if s, err = web.ReturnOutputHtml(output); err != nil {
+				return err
+			}
+		}
+	}
+
+	if outputS3Bucket != "" {
+		ext := "html"
+		contentType := "text/html"
+		if outputType == "text" {
+			ext = "txt"
+			contentType = "text/plain"
+		}
+
+		// make a unique ID for the file
+		// XXX: we can consider different algorithms or methods here later...
+		// We want this hash to be basically impossible
+		// to guess, so that you can only get it if you
+		// have the secret link.
+		if bigIntStr == "" { // make sure we really have one
+			// programming error
+			return fmt.Errorf("random number generation logic error")
+		}
+		now := strconv.FormatInt(time.Now().UnixMilli(), 10) // itoa but int64
+		sum := sha512.Sum512([]byte(s + now + bigIntStr))    // XXX: for now
+		uid := fmt.Sprintf("%x", sum)
+		objectName := fmt.Sprintf("%s-%s.%s", program, uid, ext) // TODO: arbitrary
+
+		inputs := &s3.Inputs{
+			Region:            region,
+			BucketName:        outputS3Bucket,
+			CreateBucket:      true,
+			ObjectName:        objectName,
+			GrantReadAllUsers: true,
+			ContentType:       &contentType,
+			Data:              []byte(s),
+			Debug:             debug,
+			Logf: func(format string, v ...interface{}) {
+				logf("s3: "+format, v...)
+			},
+		}
+		// XXX: find a way to check if credentials are
+		// good, early in the operation before the scan,
+		// otherwise we will end up running a whole scan
+		// and then throwing away the results...
+		u, err := s3.Store(ctx, inputs)
+		if err != nil {
+			logf("could not write s3 file: %+v", err)
+		} else {
+			fmt.Printf("S3 Sig URL: %s\n", u)
+			fmt.Printf("S3 Pub URL: %s\n", s3.PubURL(region, outputS3Bucket, objectName))
+		}
+	}
+
+	if outputPath == "-" {
+		// NOTE: if we get asked for stdout, we
+		// turn off other output to make it sane
+		// TODO: should logs go to stderr instead?
+		quiet = true           // redundant for now
+		_, err := fmt.Print(s) // to stdout
+		return err
+
+	} else if outputPath != "" {
+		// TODO: is this the umask we should use?
+		if err := os.WriteFile(outputPath, []byte(s), interfaces.Umask); err != nil {
+			logf("could not write output file: %+v", err)
+		}
+	}
+
+	if !quiet {
+		s, err := lib.ReturnOutputConsole(output)
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(s) // display it
+	}
+
+	return nil
+}
+
 // Config is a list of settings stored in the users ~/.config/ directory.
 // TODO: should this get moved into the lib package?
 type Config struct {
+	// AutoConfigURI is a special URI which if set, will try and pull a
+	// config from that location on startup. It will use the cookie file
+	// stored at AutoConfigCookiePath if specified. If successful, it will
+	// check if the config is different from what is currently stored. If so
+	// then it will validate if it is a valid json config. If so it will
+	// replace (overwrite!) the current config and then recursively begin
+	// the process again. The only thing preventing infinite recursion here
+	// is the fact that you probably would not chain 100 configs, one after
+	// another...
+	AutoConfigURI *string `json:"auto-config-uri"`
+
+	// AutoConfigCookiePath is a special URI which if set will point to a
+	// netscape/libcurl style cookie file to use when making the get
+	// download requests. This is useful if you store your config behind
+	// some gateway that needs a magic cookie for auth.
+	AutoConfigCookiePath *string `json:"auto-config-cookie-path"`
+
 	// Quiet will prevent the tool from talking too much on the console.
 	// This is implied if you use the stdout option of --output-path.
 	Quiet *bool `json:"quiet"`
@@ -428,25 +543,15 @@ type Config struct {
 }
 
 // GetConfig loads the config file data into a struct.
-func GetConfig(configPath string) (*Config, error) {
-	// If config path is set, we look in there for a config, otherwise we
-	// use the default xdg path.
-	if configPath == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, errwrap.Wrapf(err, "error finding home directory")
-		}
-		if home == "" {
-			return nil, fmt.Errorf("home directory is empty")
-		}
+func GetConfig(p string) (*Config, error) {
 
-		// TODO: get program from an input var perhaps?
-		configPath = filepath.Join(home, ".config/", program+"/", ConfigFileName)
-		configPath = filepath.Clean(configPath)
+	configPath, err := GetConfigPath(p)
+	if err != nil {
+		return nil, err
 	}
 
 	data, err := os.ReadFile(configPath)
-	if os.IsNotExist(err) && configPath == "" {
+	if os.IsNotExist(err) && p == "" {
 		return nil, nil // no config, no error
 	}
 	if err != nil {
@@ -466,6 +571,80 @@ func GetConfig(configPath string) (*Config, error) {
 	}
 
 	return &configData, nil
+}
+
+// GetConfigPath returns the expected path to the main config.json file given
+// the input arg for that setting.
+func GetConfigPath(configPath string) (string, error) {
+	// If config path is set, we look in there for a config, otherwise we
+	// use the default xdg path.
+	if configPath != "" {
+		return configPath, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errwrap.Wrapf(err, "error finding home directory")
+	}
+	if home == "" {
+		return "", fmt.Errorf("home directory is empty")
+	}
+
+	// TODO: get program from an input var perhaps?
+	p := filepath.Join(home, ".config/", program+"/", ConfigFileName)
+	return filepath.Clean(p), nil
+}
+
+// DownloadConfig pulls a config from a magic URI and returns the contents.
+func DownloadConfig(uri string) ([]byte, error) {
+	if uri == "" {
+		return nil, fmt.Errorf("empty URI")
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme == "https" {
+		client := &http.Client{
+			CheckRedirect: func() func(req *http.Request, via []*http.Request) error {
+				redirects := 0
+				return func(req *http.Request, via []*http.Request) error {
+					if redirects > MaxRedirects {
+						return fmt.Errorf("stopped after %d redirects", MaxRedirects)
+					}
+					redirects++
+					return nil
+				}
+			}(),
+		}
+		if autoConfigCookiePath != "" {
+			p, err := homedir.Expand(autoConfigCookiePath)
+			if err != nil {
+				return nil, errwrap.Wrapf(err, "invalid path of: %s", autoConfigCookiePath)
+			}
+			cookieJar, err := cookiejarparser.LoadCookieJarFile(p)
+			if err != nil {
+				return nil, errwrap.Wrapf(err, "error loading cookie from: %s", autoConfigCookiePath)
+			}
+			client.Jar = cookieJar
+		}
+
+		resp, err := client.Get(uri)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("unsupported URI: %s", uri)
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/go-git/go-git/v5 v5.3.0 // indirect
 	github.com/google/licenseclassifier v0.0.0-20210325184830-bb04aff29e72 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/ssgelm/cookiejarparser v1.0.1 // indirect
 	github.com/urfave/cli/v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/ssgelm/cookiejarparser v1.0.1 h1:cRdXauUbOTFzTPJFaeiWbHnQ+tRGlpKKzvIK9PUekE4=
+github.com/ssgelm/cookiejarparser v1.0.1/go.mod h1:DUfC0mpjIzlDN7DzKjXpHj0qMI5m9VrZuz3wSlI+OEI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -181,6 +183,7 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20191027093000-83d349e8ac1a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897 h1:KrsHThm5nFk34YtATK1LsThyGhGbGe1olrte/HInHvs=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=


### PR DESCRIPTION
This allows users to set custom auto-config URI's so that centralized
configuration can be employed. It also adds the plumbing and tools to
enable you to bake in the auto config URI into a self-built binary so
that a single executable will download the configuration from your
server.